### PR TITLE
Create a media session to receive media button events instead of Spotify

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -177,6 +177,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'androidx.media:media:1.0.0'
     implementation 'io.requery:sqlite-android:3.27.1'
     implementation 'android.arch.persistence:db-framework:1.1.1'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'


### PR DESCRIPTION
## Purpose / Description
Fix audio bug where bluetooth button presses were being sent to audio apps, not consumed by AnkiDroid. Note, volume buttons continue to change the media volume, as they are not handled in the same way as play/pause/skip buttons.

## Approach
The Reviewer.java Activity is the Activity that runs when reviewing flashcards. By creating a MediaSession object in that Activity, we can tell the system to send all media button presses to our MediaSession instead of others (like Spotify's MediaSession). When we receive a media button press, we can just ignore it and things work out beautifully.

## How Has This Been Tested?
On my Fire tablet.

## Learning (optional, can help others)
- [Google documentation around using MediaSession objects](https://developer.android.com/guide/topics/media-apps/working-with-a-media-session.html) was helpful for understanding how to initialize the MediaSession object properly. Incorrect initialization results in the system not identifying AnkiDroid as the primary audio app, which causes button presses to slip through. Once you initialize the MediaSession properly in the right Activity (Reviewer.java), it works well.
- [Google documentation around handling media buttons](https://developer.android.com/guide/topics/media-apps/mediabuttons#mediabuttons-and-active-mediasessions) was somewhat helpful as a reference, but generally assumes you are actually playing music, which we are not.

