### PR TITLE
Switch to showing young cards due instead of minimum interval; hide toolbar cards/mins due

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1975,7 +1975,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
                             time = res.getString(R.string.time_quantity_minutes, eta);
                         }
                         if (getSupportActionBar() != null) {
-                            getSupportActionBar().setSubtitle(res.getQuantityString(R.plurals.deckpicker_title, due, due, time));
+                            //Don't show cards due
+                            //getSupportActionBar().setSubtitle(res.getQuantityString(R.plurals.deckpicker_title, due, due, time));
                         }
                     }
                 } catch (RuntimeException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -91,14 +91,14 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
             super(v);
             deckLayout = (RelativeLayout) v.findViewById(R.id.DeckPickerHoriz);
             countsLayout = (LinearLayout) v.findViewById(R.id.counts_layout);
-            youngRevLayout = (LinearLayout) v.findViewById(R.id.min_ivl_layout);
+            youngRevLayout = (LinearLayout) v.findViewById(R.id.young_rev_layout);
             deckExpander = (ImageButton) v.findViewById(R.id.deckpicker_expander);
             indentView = (ImageButton) v.findViewById(R.id.deckpicker_indent);
             deckName = (TextView) v.findViewById(R.id.deckpicker_name);
             deckNew = (TextView) v.findViewById(R.id.deckpicker_new);
             deckLearn = (TextView) v.findViewById(R.id.deckpicker_lrn);
             deckRev = (TextView) v.findViewById(R.id.deckpicker_rev);
-            youngRevCount = (TextView) v.findViewById(R.id.deckpicker_min_ivl);
+            youngRevCount = (TextView) v.findViewById(R.id.deckpicker_young_rev);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -80,25 +80,25 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
     public class ViewHolder extends RecyclerView.ViewHolder {
         public RelativeLayout deckLayout;
         public LinearLayout countsLayout;
-        public LinearLayout minIvlLayout;
+        public LinearLayout youngRevLayout;
         public ImageButton deckExpander;
         public ImageButton indentView;
         public TextView deckName;
         public TextView deckNew, deckLearn, deckRev;
-        public TextView minIvl;
+        public TextView youngRevCount;
 
         public ViewHolder(View v) {
             super(v);
             deckLayout = (RelativeLayout) v.findViewById(R.id.DeckPickerHoriz);
             countsLayout = (LinearLayout) v.findViewById(R.id.counts_layout);
-            minIvlLayout = (LinearLayout)v.findViewById(R.id.min_ivl_layout);
+            youngRevLayout = (LinearLayout) v.findViewById(R.id.min_ivl_layout);
             deckExpander = (ImageButton) v.findViewById(R.id.deckpicker_expander);
             indentView = (ImageButton) v.findViewById(R.id.deckpicker_indent);
             deckName = (TextView) v.findViewById(R.id.deckpicker_name);
             deckNew = (TextView) v.findViewById(R.id.deckpicker_new);
             deckLearn = (TextView) v.findViewById(R.id.deckpicker_lrn);
             deckRev = (TextView) v.findViewById(R.id.deckpicker_rev);
-            minIvl = (TextView) v.findViewById(R.id.deckpicker_min_ivl);
+            youngRevCount = (TextView) v.findViewById(R.id.deckpicker_min_ivl);
         }
     }
 
@@ -208,14 +208,14 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
 
         // Init vars to determine what metadata to show about decks
         boolean showRemainingCards;
-        boolean showMinimumInterval;
+        boolean showYoungReviewCount;
         try {
             showRemainingCards = mCol.getConf().getBoolean("dueCounts");
             // why isn't what follows another call to mCol.getConf()...?
             // didn't want to modify anki collection prefs json object at this point
             // so it must go through Android's preference system, which requires a Context object
             Context context = holder.itemView.getContext();
-            showMinimumInterval = AnkiDroidApp.getSharedPrefs(context).getBoolean(context.getString(R.string.pref_show_min_interval), false);
+            showYoungReviewCount = AnkiDroidApp.getSharedPrefs(context).getBoolean(context.getString(R.string.pref_young_cards_due), false);
         } catch (JSONException e) {
             throw new IllegalStateException("Failed to find 'dueCounts' field in collection prefs");
         }
@@ -245,14 +245,14 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
         }
 
         // Show/hide the minimum interval information
-        if (showMinimumInterval) {
-            holder.minIvlLayout.setVisibility(View.VISIBLE);
-            holder.minIvl.setVisibility(View.VISIBLE);
-            int doneReviewingIvl = 21; // if minIvl is 21 days, all your cards are mature and you
-            if (node.minIvl > doneReviewingIvl) {
-                holder.minIvl.setText(HtmlCompat.fromHtml("\uD83D\uDC4D", HtmlCompat.FROM_HTML_MODE_LEGACY)); // thumbs up
+        if (showYoungReviewCount) {
+            holder.youngRevLayout.setVisibility(View.VISIBLE);
+            holder.youngRevCount.setVisibility(View.VISIBLE);
+            int doneReviewingYoungCount = 10; // if the amount of young reviews due is less than (or equal to) 10, we're g2g
+            if (node.youngRevCount <= doneReviewingYoungCount) {
+                holder.youngRevCount.setText(HtmlCompat.fromHtml("\uD83D\uDC4D", HtmlCompat.FROM_HTML_MODE_LEGACY)); // thumbs up
             } else {
-                holder.minIvl.setText(String.format("%dd", node.minIvl));
+                holder.youngRevCount.setText(String.format("%d", node.youngRevCount));
             }
             // also show any cards in learning stage
             if (node.lrnCount > 0) {
@@ -263,10 +263,10 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
                     .setTextColor(ContextCompat.getColor(holder.itemView.getContext(), R.color.black));
             }
         } else {
-            // only need to update minIvl views here because views for cards in "learn" state
+            // only need to update youngRevCount views here because views for cards in "learn" state
             // will be properly configured in previous conditionals
-            holder.minIvlLayout.setVisibility(View.INVISIBLE);
-            holder.minIvl.setVisibility(View.INVISIBLE);
+            holder.youngRevLayout.setVisibility(View.INVISIBLE);
+            holder.youngRevCount.setVisibility(View.INVISIBLE);
         }
 
         // Store deck ID in layout's tag for easy retrieval in our click listeners

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -403,9 +403,9 @@ public class SchedV2 extends Sched {
                 }
                 int rlim = _deckRevLimitSingle(deck, plim);
                 int rev = _revForDeck(deck.getLong("id"), rlim, childMap);
-                int minIvl = _minIvlForDeck(deck.getLong("id"), rev);
+                int youngRevCountForDeck = _youngRevCountForDeck(deck.getLong("id"));
                 // save to list
-                data.add(new DeckDueTreeNode(deck.getString("name"), deck.getLong("id"), rev, lrn, _new, minIvl));
+                data.add(new DeckDueTreeNode(deck.getString("name"), deck.getLong("id"), rev, lrn, _new, youngRevCountForDeck));
                 // add deck as a parent
                 lims.put(deck.getString("name"), new Integer[]{nlim, rlim});
             }
@@ -493,8 +493,8 @@ public class SchedV2 extends Sched {
             } catch (JSONException e) {
                 throw new RuntimeException(e);
             }
-            int minIvl = _minIvlForDeck(did, rev);
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, minIvl, children));
+            int youngRevCountForDeck = _youngRevCountForDeck(did);
+            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, youngRevCountForDeck, children));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/res/layout/deck_item.xml
+++ b/AnkiDroid/src/main/res/layout/deck_item.xml
@@ -37,7 +37,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_toRightOf="@+id/deckpicker_indent"
-        android:layout_toLeftOf="@+id/min_ivl_layout"
+        android:layout_toLeftOf="@+id/young_rev_layout"
         android:orientation="horizontal"
         android:gravity="center_vertical">
         <ImageButton
@@ -62,7 +62,7 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/min_ivl_layout"
+        android:id="@+id/young_rev_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="right"
@@ -73,7 +73,7 @@
         >
 
       <TextView
-          android:id="@+id/deckpicker_min_ivl"
+          android:id="@+id/deckpicker_young_rev"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="center"

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -61,9 +61,9 @@
     <string name="button_size">Answer button size</string>
     <string name="card_browser_font_size">Card browser font scaling</string>
     <string name="col_path">AnkiDroid directory</string>
-    <string name="pref_show_min_interval" translatable="false">showMinInterval</string>
-    <string name="show_min_ivl_title" translatable="false">Show minimum interval</string>
-    <string name="show_min_ivl_summary" translatable="false">Shows/hides smallest interval for cards in deck</string>
+    <string name="pref_young_cards_due" translatable="false">showYoungCardsDue</string>
+    <string name="show_young_cards_due_title" translatable="false">Show young cards due</string>
+    <string name="show_young_cards_due_summary" translatable="false">Shows/hides total amount of young cards due in deck</string>
     <string name="fullscreen_review">Fullscreen mode</string>
     <string name="full_screen_off">Off</string>
     <string name="full_screen_system">Hide the system bars</string>

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -69,8 +69,8 @@
     <PreferenceCategory android:title="Decks">
         <CheckBoxPreference
             android:defaultValue="true"
-            android:key="@string/pref_show_min_interval"
-            android:summary="@string/show_min_ivl_summary"
-            android:title="@string/show_min_ivl_title" />
+            android:key="@string/pref_young_cards_due"
+            android:summary="@string/show_young_cards_due_summary"
+            android:title="@string/show_young_cards_due_title" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Tested on Fire 10/Note9